### PR TITLE
feat(adivinhar): save user progress & check if already playing

### DIFF
--- a/src/commands/adivinhar.js
+++ b/src/commands/adivinhar.js
@@ -126,8 +126,8 @@ async function sendGameMessageAndResults(interaction) {
 			ephemeral: true,
 		});
 
-		if (usersTries.find(user => user.id === playingUser.id)) {
-			const triesLeft = usersTries.find(user => user.id === playingUser.id).attempts.length;
+		if (usersTries.find(user => user.id === interaction.user.id)) {
+			const triesLeft = usersTries.find(user => user.id === interaction.user.id).attempts.length;
 			i = triesLeft;
 		}
 		else {
@@ -169,7 +169,7 @@ async function sendGameMessageAndResults(interaction) {
 						.setStyle('SUCCESS'),
 				);
 
-			usersTries.find(player => player.id === playingUser.id).attempts.push(await convertContentToEmojis(word, correctWord));
+			usersTries.find(player => player.id === interaction.user.id).attempts.push(await convertContentToEmojis(word, correctWord));
 
 			if (word === correctWord) {
 				await interaction.editReply(`Parabéns, você acertou em ${i + 1} tentativas! :tada:\n\n${returnGameTable()}`);

--- a/src/commands/adivinhar.js
+++ b/src/commands/adivinhar.js
@@ -147,7 +147,7 @@ async function sendGameMessageAndResults(interaction) {
 
 		if (word === 'cancelar') {
 			await interaction.editReply('Você encerrou o jogo :(');
-			activeGames[interaction.user.id] = null;
+			delete activeGames[interaction.user.id];
 			i = 7;
 		}
 		else if (word.length != 5) {
@@ -177,7 +177,7 @@ async function sendGameMessageAndResults(interaction) {
 				await interaction.editReply(`Parabéns, você acertou em ${i + 1} tentativas! :tada:\n\n${returnGameTable()}`);
 				await itPlayed(interaction.user.id);
 
-				usersTries[interaction.user.id] = null;
+				delete usersTries[interaction.user.id];
 
 				await interaction.channel.send(`<@${interaction.user.id}> Precione o botão correspondente à plataforma em que está jogando para que seja possível copiar a mensagem e compartilhá-la!`);
 				const msg = await interaction.channel.send({
@@ -206,7 +206,7 @@ async function sendGameMessageAndResults(interaction) {
 					await interaction.editReply(`${returnGameTable()}\n\nVocê perdeu, a palavra era **${correctWord}**. :frowning:\nQuem sabe na próxima você consegue!`);
 					await itPlayed(interaction.user.id);
 
-					activeGames[interaction.user.id] = null;
+					delete activeGames[interaction.user.id];
 
 					await interaction.channel.send(`<@${interaction.user.id}> Pressione o botão correspondente à plataforma em que está jogando para que seja possível copiar a mensagem e compartilhá-la!`);
 					const msg = await interaction.channel.send({

--- a/src/commands/adivinhar.js
+++ b/src/commands/adivinhar.js
@@ -65,8 +65,8 @@ async function iosOrAndroidPc(interaction) {
 	return plataform;
 }
 
-const usersTries = {};
-const activeGames = {};
+let usersTries = {};
+let activeGames = {};
 
 setInterval(() => {
 	const brazilianTime = dayjs().tz('America/Sao_Paulo').format('HH:mm');
@@ -82,7 +82,7 @@ async function sendGameMessageAndResults(interaction) {
 		await interaction.reply('Ops! Parece que eu não tenho permissão para executar esse comando.\nPor favor, me dê um cargo que tenha permissão de `Gerenciar mensagens`.');
 		return;
 	}
-	
+
 	const playingUser = { id: interaction.user.id, attempts: [] };
 	const correctWord = await checkWordDatabase();
 
@@ -147,7 +147,7 @@ async function sendGameMessageAndResults(interaction) {
 
 		if (word === 'cancelar') {
 			await interaction.editReply('Você encerrou o jogo :(');
-			activeGames[interaction.user.id] = null;			
+			activeGames[interaction.user.id] = null;
 			i = 7;
 		}
 		else if (word.length != 5) {

--- a/src/commands/adivinhar.js
+++ b/src/commands/adivinhar.js
@@ -96,17 +96,18 @@ async function sendGameMessageAndResults(interaction) {
 	};
 
 	function returnGameTable() {
-		if (!usersTries.find(user => user.id === interaction.user.id)) {
+		const userTries = usersTries.find(user => user.id === interaction.user.id);
+
+		if (!userTries) {
 			return Object.values(gameMessage).map(line => line).join('\n');
 		}
 		else {
-			const userTries = usersTries.find(user => user.id === interaction.user.id).attempts;
 			for (let i = 0; i < 6; i++) {
-				if (userTries[i] === undefined) {
+				if (!userTries.attempts[i]) {
 					gameMessage[`line${i + 1}`] = `${square['gray'].repeat(5)}`;
 				}
 				else {
-					gameMessage[`line${i + 1}`] = userTries[i];
+					gameMessage[`line${i + 1}`] = userTries.attempts[i];
 				}
 			}
 			return Object.values(gameMessage).map(line => line).join('\n');
@@ -126,8 +127,9 @@ async function sendGameMessageAndResults(interaction) {
 			ephemeral: true,
 		});
 
-		if (usersTries.find(user => user.id === interaction.user.id)) {
-			const triesLeft = usersTries.find(user => user.id === interaction.user.id).attempts.length;
+		const userTries = usersTries.find(user => user.id === interaction.user.id);
+		if (userTries) {
+			const triesLeft = userTries.attempts.length;
 			i = triesLeft;
 		}
 		else {


### PR DESCRIPTION
#### This PR:
- Saves the user progress, i.e. it will still show the words that the user already submitted (this is made by cancelling the game and using the `/adivinhar` command again);
- Check if the user is in an active game, if not it will show an error.

```mermaid
  graph TD;
A[Interaction]-->B{Is in activeGames?};
B -- Yes --> C[Reply with an error];
B -- No --> D[Send the gameMessage and push user ID to activeGames];
D --> E{Is in usersTries?};
E -- Yes --> F[Modify the i, so the for loop will start after];
E -- No --> G[Push playingUser to userTries];
```